### PR TITLE
Fix TZ about RSS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install, build, and upload your site
         uses: withastro/action@v0
+        env:
+          TZ: 'Asia/Tokyo'
 
   deploy:
     needs: build

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -18,7 +18,7 @@ export async function get(context) {
     items: articles.map((article) => ({
       title: article.title,
       description: `By ${article.author}`,
-      pubDate: article.date,
+      pubDate: dayjs(article.date).toDate(),
       link: article.url,
     })),
   });


### PR DESCRIPTION
- https://github.com/vim-jp/ekiden/pull/26 に対する修正
- この変更でいい感じに動くことを確認しました
  - 3/3 0:00 ～ 9:00 JST の間に、
    - TZ の変更がない状態でデプロイし、3/3 のエントリーが rss.xml に入っていないことを確認
    - TZ の変更がある状態でデプロイし、3/3 のエントリーが rss.xml に入っていることを確認
  - pubDate は dayjs がデフォルトでローカルタイムで Date を構築することを利用
    - dayjs 自体を pubDate に渡すことはできないので、これを Date に変換
    - `newDate(article.date)` だと GMT 0:00 になってしまい、うまくいかない
    - 1 つ前のコミットで TZ が設定されていることに依存している